### PR TITLE
Allow specifying an output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .gradle
 .idea
 build/
+bin/
+extracted/
+workspace/

--- a/src/main/java/ovh/akio/hmu/Application.java
+++ b/src/main/java/ovh/akio/hmu/Application.java
@@ -124,7 +124,7 @@ public class Application implements Callable<Integer> {
             return 1;
         }
 
-        GameUnpacker unpacker = new GameUnpacker(game, this.threadCount, outputFolder);
+        GameUnpacker unpacker = new GameUnpacker(game, this.threadCount, this.outputFolder);
 
         // Cleaning up the previous runs
         System.out.println("Removing previous files...");

--- a/src/main/java/ovh/akio/hmu/Application.java
+++ b/src/main/java/ovh/akio/hmu/Application.java
@@ -53,6 +53,13 @@ public class Application implements Callable<Integer> {
     private File gameFolder;
 
     @CommandLine.Option(
+            names = {"-o", "--output"},
+            description = "Output folder for the extracted files",
+            defaultValue = ""
+    )
+    private File outputFolder;
+
+    @CommandLine.Option(
             names = {"-d", "--diff"},
             description = "Extract update package only",
             defaultValue = "false"
@@ -117,7 +124,7 @@ public class Application implements Callable<Integer> {
             return 1;
         }
 
-        GameUnpacker unpacker = new GameUnpacker(game, this.threadCount);
+        GameUnpacker unpacker = new GameUnpacker(game, this.threadCount, outputFolder);
 
         // Cleaning up the previous runs
         System.out.println("Removing previous files...");

--- a/src/main/java/ovh/akio/hmu/GameUnpacker.java
+++ b/src/main/java/ovh/akio/hmu/GameUnpacker.java
@@ -47,7 +47,7 @@ public class GameUnpacker {
 
     public File getUnpackingOutput() {
 
-        return Utils.asLocalDirectory(outputDir, this.game.getShortName());
+        return Utils.asLocalDirectory(this.outputDir, this.game.getShortName());
     }
 
     private <T extends AudioFile> void run(String name, File output, AudioConverter<T> converter, Collection<T> files) {

--- a/src/main/java/ovh/akio/hmu/GameUnpacker.java
+++ b/src/main/java/ovh/akio/hmu/GameUnpacker.java
@@ -19,17 +19,25 @@ import java.util.concurrent.Executors;
 
 public class GameUnpacker {
 
+    private final File               outputDir;
     private final HoyoverseGame      game;
     private final ExecutorService    service;
     private final List<PckAudioFile> pckAudioFiles;
     private final List<WemAudioFile> wemAudioFiles;
 
-    public GameUnpacker(HoyoverseGame game, int maxThreads) {
+    public GameUnpacker(HoyoverseGame game, int maxThreads, File outputDir) {
 
         this.game          = game;
         this.service       = Executors.newFixedThreadPool(Math.max(maxThreads, 1));
         this.pckAudioFiles = this.game.getAudioFiles();
         this.wemAudioFiles = new ArrayList<>();
+
+        // If an output dir is selected, use it. Otherwise return the current directory
+        if (!outputDir.getName().equals("")) {
+            this.outputDir = new File(outputDir, "extracted");
+        } else {
+            this.outputDir = new File(".", "extracted");
+        }
     }
 
     public File getWorkspace() {
@@ -39,7 +47,7 @@ public class GameUnpacker {
 
     public File getUnpackingOutput() {
 
-        return Utils.asLocalDirectory("extracted", this.game.getShortName());
+        return Utils.asLocalDirectory(outputDir, this.game.getShortName());
     }
 
     private <T extends AudioFile> void run(String name, File output, AudioConverter<T> converter, Collection<T> files) {


### PR DESCRIPTION
This PR adds the ability to specify where your extracted files are placed with the output option.

Usage: `java -jar "//path/to/jar" --game='//path/to/game' --output="F:\Users\User\Music"`

I tested with and without the flag and it worked fine. I only used Genshin, but I'm assuming that since this is before the game-specific path it should work the same.

Closes #7 