### PR TITLE
Optional value for decompressing all audio files, not just music

### DIFF
--- a/src/main/java/ovh/akio/hmu/Application.java
+++ b/src/main/java/ovh/akio/hmu/Application.java
@@ -24,12 +24,22 @@ import java.util.stream.Stream;
         version = "Hoyoverse Audio Extractor 1.2"
 )
 public class Application implements Callable<Integer> {
+    public Application() {
+        MAIN = this;
+    }
 
     private static final int CODE_OK                   = 0;
     private static final int CODE_DIFF_MODE_IMPOSSIBLE = 1;
     private static final int CODE_NO_UPDATE            = 2;
 
+    public static Application MAIN;
 
+    @CommandLine.Option(
+            names ={"-a", "--all"},
+            description = "Search for all valid audio files (not just music)",
+            defaultValue="false"
+    )
+    public boolean AllowAnyAudioFiles;
     @CommandLine.Option(
             names = {"-g", "--game"},
             description = "Installation folder of the game",
@@ -66,7 +76,6 @@ public class Application implements Callable<Integer> {
     private int threadCount;
 
     public static void main(String... args) {
-
         System.exit(new CommandLine(new Application()).execute(args));
     }
 

--- a/src/main/java/ovh/akio/hmu/Utils.java
+++ b/src/main/java/ovh/akio/hmu/Utils.java
@@ -114,7 +114,7 @@ public class Utils {
             return Collections.emptyList();
         }
 
-        if (!Application.MAIN.AllowAnyAudioFiles) {
+        if (Application.MAIN.AllowAnyAudioFiles) {
             return Utils.getDirectoryContent(path)
                     .stream()
                     .filter(File::isFile)

--- a/src/main/java/ovh/akio/hmu/Utils.java
+++ b/src/main/java/ovh/akio/hmu/Utils.java
@@ -114,12 +114,21 @@ public class Utils {
             return Collections.emptyList();
         }
 
-        return Utils.getDirectoryContent(path)
+        if (!Application.MAIN.AllowAnyAudioFiles) {
+            return Utils.getDirectoryContent(path)
+                    .stream()
+                    .filter(File::isFile)
+                    .filter(file -> file.getName().endsWith(".pck"))
+                    .map(PckAudioFile::new)
+                    .toList();
+        } else {
+            return Utils.getDirectoryContent(path)
                     .stream()
                     .filter(File::isFile)
                     .filter(file -> file.getName().endsWith(".pck"))
                     .filter(file -> file.getName().startsWith("Minimum") || file.getName().startsWith("Music"))
                     .map(PckAudioFile::new)
                     .toList();
+        }
     }
 }


### PR DESCRIPTION
-a, --all (default:false): allows any audio file to be supplied to the output folder *Note: folder size will be VERY large.